### PR TITLE
Change tutorial link from ipynb to PDF

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 
 ## What is PyNormaliz
 
-PyNormaliz provides an interface to Normaliz (https://www.normaliz.uni-osnabrueck.de) via libNormaliz. It offers the complete functionality of Normaliz, and can be used interactively from python. For a first example, see [this introduction](doc/PyNormaliz_Tutorial.ipynb) by Richard Sieg.
+PyNormaliz provides an interface to Normaliz (https://www.normaliz.uni-osnabrueck.de) via libNormaliz. It offers the complete functionality of Normaliz, and can be used interactively from python. For a first example, see [this introduction](doc/PyNormaliz_Tutorial.pdf) by Richard Sieg.
 
 
 ## Requirements


### PR DESCRIPTION
The .ipynb is not readable in browsers, but the generated PDF is. This fixes the link so that the tutorial can be read.