### PR TITLE
Tweak Travis settings

### DIFF
--- a/.travis-install-normaliz.sh
+++ b/.travis-install-normaliz.sh
@@ -47,7 +47,7 @@ sudo cp nauty.a /usr/local/lib/libnauty.a
 git clone --depth=1 https://github.com/Normaliz/Normaliz
 cd Normaliz
 ./bootstrap.sh
-./configure --disable-scip --disable-nmzintegrate $NMZ_ENF --prefix=/usr
+./configure --disable-nmzintegrate $NMZ_ENF --prefix=/usr
 make
 sudo make install
 cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 dist: xenial
-language: c
+language: python
+python:
+  - "2.7"
+  - "3.6"
 cache: ccache
 addons:
   apt:
@@ -12,34 +15,23 @@ addons:
       - autoconf
       - automake
       - libtool
-      - python-pip
-      - python3-pip
-      - python3-setuptools
 env:
-  - PY="2"
-    EANTIC="no"
-  - PY="2"
-    EANTIC="yes"
-  - PY="3"
-    EANTIC="no"
-  - PY="3"
-    EANTIC="yes"
+  - EANTIC=no
+  - EANTIC=yes
 install:
-  - export MAKE="make -j2"
-  - export PYTHON="python${PY}"
-  - export PIP="pip${PY}"
-  - export PIPINSTALL="${PIP} install --no-index --no-deps -v"
+  - export MAKEFLAGS="-j2"
+  - export PIP=$(which pip) # workaround so that sudo uses correct pip
   # install normaliz
   - ./.travis-install-normaliz.sh
   # install pynormaliz
-  - sudo $PIPINSTALL .
+  - sudo $PIP install --no-index --no-deps -v .
 script:
   - export OMP_NUM_THREADS=4
   # run tests
-  - $PYTHON setup.py test
+  - python setup.py test
   # uninstall, make source distribution and reinstall from it
   # and check that the module can be imported
   - sudo $PIP uninstall -y PyNormaliz
   - make sdist
-  - sudo $PIPINSTALL dist/PyNormaliz-*.tar.gz
-  - $PYTHON -c "import PyNormaliz"
+  - sudo $PIP install --no-index --no-deps -v dist/PyNormaliz-*.tar.gz
+  - python -c "import PyNormaliz"


### PR DESCRIPTION
This simplifies the Travis settings. It also makes it explicit against which Python version the tests are run, and trivial to add new Python versions, e.g. 3.7 or even Python nightlies.