### PR TITLE
Revert "Fix warnings about unused code"

### DIFF
--- a/NormalizModule.cpp
+++ b/NormalizModule.cpp
@@ -509,6 +509,19 @@ static PyObject* NmzBoolVectorToPyList(const vector< bool >& in)
     return vector;
 }
 
+static PyObject* NmzBoolMatrixToPyList(const vector< vector< bool > >& in)
+{
+    PyObject*    matrix;
+    const size_t n = in.size();
+    matrix = PyList_New(n);
+    for (size_t i = 0; i < n; ++i) {
+        PyList_SetItem(matrix, i, NmzBoolVectorToPyList(in[i]));
+    }
+    if (MatrixHandler != NULL)
+        matrix = CallPythonFuncOnOneArg(MatrixHandler, matrix);
+    return matrix;
+}
+
 template < typename Integer >
 static PyObject* NmzMatrixToPyList(const vector< vector< Integer > >& in)
 {
@@ -826,7 +839,6 @@ static bool is_cone_long(PyObject* cone)
     return false;
 }
 
-#ifdef ENFNORMALIZ
 static bool is_cone_renf(PyObject* cone)
 {
     if (PyCapsule_CheckExact(cone)) {
@@ -835,7 +847,6 @@ static bool is_cone_renf(PyObject* cone)
     }
     return false;
 }
-#endif
 
 /***************************************************************************
  *


### PR DESCRIPTION
This reverts commit e77abd3ad19a05e1f5726fbfdf76efbeb7302467.

I don't understand why that commit was made. If you look at https://travis-ci.org/Normaliz/PyNormaliz/builds you can see that the code you reverted built and tested just fine. Only when you tagged v2.9 it didn't build fine. That clearly indicates that the problem is in Normaliz, not PyNormaliz. I now also emailed you some explanations.

