### PR TITLE
Travis: send notifications for master branch failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,18 @@ addons:
 env:
   - EANTIC=no
   - EANTIC=yes
+
+# send email notifications if master branch starts failing
+# or stops failing
+notifications:
+  email:
+    if: branch = master
+    recipients:
+      - max@quendi.de
+      - wbruns@uos.de
+    on_success: change
+    on_failure: change
+
 install:
   - export MAKEFLAGS="-j2"
   - export PIP=$(which pip) # workaround so that sudo uses correct pip
@@ -25,6 +37,7 @@ install:
   - ./.travis-install-normaliz.sh
   # install pynormaliz
   - sudo $PIP install --no-index --no-deps -v .
+
 script:
   - export OMP_NUM_THREADS=4
   # run tests


### PR DESCRIPTION
That is, send them once master starts or stops to fail, but not
for each failure. This, combined with the Travis 24h cron job for
master should help ensure we notice regressions more quickly.

I am not quite sure how best to find out how to test this. Perhaps I can interrupt some regular `master` build to "fake" a failure... Or we push something that fails, and then undo it. Hm.


Resolves #79 (I hope -- similar configs work elsewhere, though)