### PR TITLE
Refactor .travis-install-normaliz.sh, fix code coverage, fix several regressions and tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,3 +3,4 @@
 #
 [run]
 source=PyNormaliz
+omit = tests

--- a/.travis-install-normaliz.sh
+++ b/.travis-install-normaliz.sh
@@ -3,52 +3,25 @@
 set -e  # exit on error
 set -x  # print command before execution
 
-if [ "$EANTIC" == "yes" ]
-then
-    NMZ_ENF="--enable-flint --enable-enfnormaliz"
+# don't pollute the PyNormaliz directory
+cd /tmp
 
-    # install arb
-    wget https://github.com/fredrik-johansson/arb/archive/2.16.0.tar.gz
-    tar xf 2.16.0.tar.gz
-    cd arb-2.16.0/
-    ./configure --prefix=/usr
-    make
-    sudo make install
-    cd ..
-
-    # install e-antic
-    wget http://www.labri.fr/perso/vdelecro/e-antic/e-antic-0.1.3b0.tar.gz
-    tar xf e-antic-0.1.3b0.tar.gz
-    cd e-antic-0.1.3b0/
-    ./configure --prefix=/usr
-    make
-    sudo make install
-    cd ..
-
-elif [ "$EANTIC" == "no" ]
-then
-    NMZ_ENF="--disable-flint --disable-enfnormaliz"
-else
-    exit 1
-fi
-
-# install nauty
-NAUTY_VERSION="27rc2"
-wget http://pallini.di.uniroma1.it/nauty${NAUTY_VERSION}.tar.gz
-tar xvf nauty${NAUTY_VERSION}.tar.gz
-cd nauty${NAUTY_VERSION}
-./configure
-make all CFLAGS=-fPIC
-sudo mkdir -p /usr/local/include/nauty
-sudo cp nauty.h /usr/local/include/nauty
-sudo cp nauty.a /usr/local/lib/libnauty.a
-
-# install normaliz
 git clone --depth=1 https://github.com/Normaliz/Normaliz
 cd Normaliz
-./bootstrap.sh
-./configure --disable-nmzintegrate $NMZ_ENF --prefix=/usr
-make
-sudo make install
-cd ..
 
+# install dependencies
+
+[ "$COCOALIB" == "yes" ] && ./install_scripts_opt/install_nmz_cocoa.sh && echo "cocoalib complete!"
+[ "$FLINT" == "yes" ] && ./install_scripts_opt/install_nmz_flint.sh && echo "flint complete!"
+[ "$EANTIC" == "yes" ] && ./install_scripts_opt/install_nmz_arb.sh && echo "arb complete!"
+[ "$EANTIC" == "yes" ] && ./install_scripts_opt/install_nmz_e-antic.sh && echo "e-antic complete!"
+[ "$NAUTY" == "yes" ] && ./install_scripts_opt/install_nmz_nauty.sh && echo "nauty complete!"
+
+# finally install Normaliz
+./bootstrap.sh
+export CPPFLAGS="${CPPFLAGS} -I${NMZ_PREFIX}/include"
+export LDFLAGS="${LDFLAGS} -L${NMZ_PREFIX}/lib"
+./configure --prefix=${NMZ_PREFIX}
+make
+make install
+cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,17 @@ cache: ccache
 addons:
   apt:
     update: true
-  apt_packages:
+    packages:
       - libgmp-dev
       - libmpfr-dev
       - libflint-dev
-      - libboost-dev
       - autoconf
       - automake
       - libtool
 env:
-  - EANTIC=no
-  - EANTIC=yes
+  - EANTIC=no NAUTY=yes COCOALIB=no #FLINT=yes
+  - EANTIC=no NAUTY=yes COCOALIB=yes #FLINT=yes
+  - EANTIC=yes NAUTY=yes COCOALIB=yes #FLINT=yes
 
 # send email notifications if master branch starts failing
 # or stops failing
@@ -31,6 +31,8 @@ notifications:
     on_failure: change
 
 install:
+  - export NMZ_PREFIX=${TRAVIS_HOME}/local
+  - export NORMALIZ_LOCAL_DIR=${NMZ_PREFIX}
   - export MAKEFLAGS="-j2"
   - export PIP=$(which pip) # workaround so that sudo uses correct pip
   - pip install coverage
@@ -44,7 +46,9 @@ script:
   - python setup.py build_ext --inplace
   # run tests
   - export OMP_NUM_THREADS=4
-  - coverage run tests/runtests.py
+  - pushd tests
+  - coverage run runtests.py
+  - popd
   # make source distribution, install from it
   # and check that the module can be imported
   - python setup.py sdist

--- a/NormalizModule.cpp
+++ b/NormalizModule.cpp
@@ -374,17 +374,11 @@ static PyObject* NmzToPyNumber(const renf_elem_class &in)
 
 PyObject* NmzToPyNumber(const dynamic_bitset& in)
 {
-    PyObject* zero = NmzToPyNumber(0);
-    PyObject* one = NmzToPyNumber(1);
     size_t    len = in.size();
     PyObject* result = PyList_New(len);
     for (size_t i = 0; i < len; i++) {
-        // use PySequence_SetItem (which increments the ref count)
-        // instead of PyList_SetItem (which does not)
-        PySequence_SetItem(result, i, in[i] ? one : zero);
+        PyList_SetItem(result, i, NmzToPyNumber(in[i] ? 1 : 0));
     }
-    Py_DecRef(one);
-    Py_DecRef(zero);
     return result;
 }
 

--- a/NormalizModule.cpp
+++ b/NormalizModule.cpp
@@ -2068,13 +2068,40 @@ static PyObject* NmzSetNumberOfNormalizThreads(PyObject* self, PyObject* args)
 
 /***************************************************************************
  *
- * Check for ENFNormaliz
+ * Check for various features
  *
  ***************************************************************************/
 
 static PyObject* NmzHasEAntic(PyObject* self)
 {
 #ifdef ENFNORMALIZ
+    Py_RETURN_TRUE;
+#else
+    Py_RETURN_FALSE;
+#endif
+}
+
+static PyObject* NmzHasNauty(PyObject* self)
+{
+#ifdef NMZ_NAUTY
+    Py_RETURN_TRUE;
+#else
+    Py_RETURN_FALSE;
+#endif
+}
+
+static PyObject* NmzHasFlint(PyObject* self)
+{
+#ifdef NMZ_FLINT
+    Py_RETURN_TRUE;
+#else
+    Py_RETURN_FALSE;
+#endif
+}
+
+static PyObject* NmzHasCocoa(PyObject* self)
+{
+#ifdef NMZ_COCOA
     Py_RETURN_TRUE;
 #else
     Py_RETURN_FALSE;
@@ -2222,8 +2249,16 @@ static PyMethodDef PyNormaliz_cppMethods[] = {
     {"NmzGetWeightedEhrhartSeriesExpansion",
      (PyCFunction)NmzGetWeightedEhrhartSeriesExpansion, METH_VARARGS,
      "Returns expansion of the weighted Ehrhart series"},
+
     {"NmzHasEAntic", (PyCFunction)NmzHasEAntic, METH_NOARGS,
      "Returns true if (Py)Normaliz was compiled with e-antic support"},
+    {"NmzHasNauty", (PyCFunction)NmzHasNauty, METH_NOARGS,
+     "Returns true if (Py)Normaliz was compiled with nauty support"},
+    {"NmzHasFlint", (PyCFunction)NmzHasFlint, METH_NOARGS,
+     "Returns true if (Py)Normaliz was compiled with Flint support"},
+    {"NmzHasCocoa", (PyCFunction)NmzHasCocoa, METH_NOARGS,
+     "Returns true if (Py)Normaliz was compiled with CoCoA support"},
+
     {"NmzWriteOutputFile", (PyCFunction)NmzWriteOutputFile, METH_VARARGS,
      "Prints the Normaliz cone output into a file"},
     {"NmzGetRenfInfo", (PyCFunction)NmzGetRenfInfo, METH_VARARGS,

--- a/tests/quasi_poly-36.txt
+++ b/tests/quasi_poly-36.txt
@@ -9,5 +9,3 @@ Bug reported in https://github.com/Normaliz/PyNormaliz/issues/36
 True
 >>> PyNormaliz.NmzResult(cube, "EhrhartQuasiPolynomial") == [[1, 3, 3, 1], 1]
 True
->>> cube.EhrhartQuasiPolynomial() == [[1, 3, 3, 1], 1]
-True

--- a/tests/rational.txt
+++ b/tests/rational.txt
@@ -7,11 +7,7 @@ Based on rational.in in Normaliz resp. rational.tst in NormalizInterface
 >>> M = [[1,1,2 ],[-1,-1,3],[1,-2,4]]
 >>> gr = [[0,0,1]]
 >>> cone = PyNormaliz.Cone(integral_closure=M, grading=gr)
->>> cone.HilbertBasis()
-[[0, 0, 1], [1, 1, 2], [-1, -1, 3], [0, -1, 3], [1, 0, 3], [1, -2, 4], [1, -1, 4], [0, -2, 5]]
->>> cone.HilbertSeries()
-[[1, 0, 0, 3, 2, -1, 2, 2, 1, 1, 1, 1, 2], [1, 2, 12], 0]
->>> cone.PrintHilbertSeries()
-(1 + 3t³ + 2t⁴ - 1t⁵ + 2t⁶ + 2t⁷ + 1t⁸ + 1t⁹ + 1t¹⁰ + 1t¹¹ + 2t¹²)
-------------------------------------------------------------------
-                    (1 - t) (1 - t²) (1 - t¹²)
+>>> cone.HilbertBasis() == [[0, 0, 1], [1, 1, 2], [-1, -1, 3], [0, -1, 3], [1, 0, 3], [1, -2, 4], [1, -1, 4], [0, -2, 5]]
+True
+>>> cone.HilbertSeries() == [[1, 0, 0, 3, 2, -1, 2, 2, 1, 1, 1, 1, 2], [1, 2, 12], 0]
+True


### PR DESCRIPTION
It turns out that adding coverage computation partially broke the code running the test suite on Travis, and as a result, we didn't execute all tests. Which immediately lead to a few PRs by me not being fully tested, and thus introducing regressions :-(

This PR restores the Travis tests to work fully, fixes coverage reporting (and thus resolves #91), and also revamps how the dependencies like nauty are compiled (which allows me to resolve #77 as well). For good measure, I then also added new functions NmzHasNauty, NmzHasFlint, NmzHasCocoa.
