### PR TITLE
Use setuptools, add GitHub workflow for uploading to PyPI on release

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,0 +1,26 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist
+        twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ with the expected value
 
     1.4142135623730951
 
-By using Python functions, the functuionality of Normaliz can be extended. For example, 
+By using Python functions, the functionality of Normaliz can be extended. For example, 
     
     def intersection(cone1, cone2):
         intersection_ineq = cone1.SupportHyperplanes()+cone2.SupportHyperplanes()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [metadata]
 description-file = README.md
+long-description-content-type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,9 @@
 [metadata]
-description-file = README.md
-long-description-content-type = text/markdown
+name = PyNormaliz
+version = 2.10
+description = An interface to Normaliz
+author = Sebastian Gutsche, Richard Sieg
+author_email = sebastian.gutsche@gmail.com
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/Normaliz/PyNormaliz

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-from distutils.core import setup, Extension
+from setuptools import setup
+from distutils.core import Extension
 from distutils.cmd import Command
 from distutils.command.build_ext import build_ext as _build_ext
 
@@ -24,19 +25,8 @@ else:
 
 from os import path
 import io
-this_directory = path.abspath(path.dirname(__file__))
-with io.open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
-    long_description = f.read()
 
 setup(
-    name = 'PyNormaliz',
-    version = '2.10',
-    description = 'An interface to Normaliz',
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    author = 'Sebastian Gutsche, Richard Sieg',
-    author_email = 'sebastian.gutsche@gmail.com',
-    url = 'https://github.com/Normaliz/PyNormaliz',
     py_modules = [ "PyNormaliz" ],
     ext_modules = [ Extension( "PyNormaliz_cpp",
                               [ "NormalizModule.cpp" ],


### PR DESCRIPTION
For the GitHub workflow to work, secrets  `PYPI_PASSWORD` and `PYPI_USERNAME` need to be added in PyNormaliz repository settings on GitHub.
Best to use PyPI API tokens (https://pypi.org/manage/account/token/) instead of actual passwords.