### PR TITLE
.github/workflows/dist.yml: Switch to passagemath/passagemath 

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -71,8 +71,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository:   sagemath/sage
-          ref:          develop
+          repository:   passagemath/passagemath
+          ref:          main
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
@w-bruns The current PyNormaliz release does not have binary wheels because https://github.com/Normaliz/PyNormaliz/actions/runs/11251270348/job/31281973263 failed because of a mismatched version of normaliz.

This PR switches the repository from sagemath/sage to passagemath/passagemath (which has done the update of normaliz to 3.10.4).
